### PR TITLE
Small fix VignetteIndexEntry with vignette title

### DIFF
--- a/vignettes/app.Rmd
+++ b/vignettes/app.Rmd
@@ -3,7 +3,7 @@ title: "How to repvisforODK - the App"
 output: 
   rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{app}
+  %\VignetteIndexEntry{How to repvisforODK - the App}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/intro_and_function_overview.Rmd
+++ b/vignettes/intro_and_function_overview.Rmd
@@ -5,7 +5,7 @@ output:
     toc: TRUE
     number_section: TRUE
 vignette: >
-  %\VignetteIndexEntry{overview}
+  %\VignetteIndexEntry{How to repvisforODK - Intro and Function Overview}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
devtools::check() raises an error as \VignetteIndexEntry{} does not match the title of your vignette.
![image](https://user-images.githubusercontent.com/71643277/150931880-4d94a405-8a70-4711-98e2-fe3cc63955a0.png)

[Link to vignette doc](https://bookdown.org/yihui/rmarkdown/r-package-vignette.html)
![image](https://user-images.githubusercontent.com/71643277/150931723-395ab137-b58a-4c73-b92c-ff900ed62e1c.png)
