### PR TITLE
Fix is.POSIXct and is.POSIXlt issue

### DIFF
--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -111,7 +111,7 @@ function(input, output) {
   shiny::observeEvent(input$load_preview_button, {
 
     # get all columns that have class POSIXct or POSIXlt
-    datetime_col_choices <- colnames(df() %>% dplyr::select_if(function(col) is.POSIXct(col) | is.POSIXlt(col)))
+    datetime_col_choices <- colnames(df() %>% dplyr::select_if(function(col) lubridate::is.POSIXct(col) | lubridate::is.POSIXlt(col)))
     shiny::updateRadioButtons(inputId = 'filter_col',
                        choices = datetime_col_choices)
     shiny::updateSelectInput(inputId = 'date_col_param',


### PR DESCRIPTION
Hi Lucas,

I had exactly the same issue Aurelio encountered - I have checked the history on GitHub and I have not been able to identify what update has led to this error (among the latest changes I suspect? maybe something with the namespaces?)
However, I have found that while **as**.POSIXct and **as**.POSIXlt are indeed **base** functions, **is**.POSIXct and **is**.POSIXlt are **lubridate** functions, which is slightly tricky!
Adding the namespace lubridate seems to make the trick - at least on my side